### PR TITLE
Add validate_cmd to the config.json

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -130,6 +130,7 @@ class consul::config (
     group   => $consul::group_real,
     mode    => $consul::config_mode,
     content => consul::sorted_json($config_hash, $consul::pretty_config, $consul::pretty_config_indent),
+    validate_cmd => "${consul::bin_dir}/${consul::binary_name} validate %",
   }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -130,7 +130,7 @@ class consul::config (
     group   => $consul::group_real,
     mode    => $consul::config_mode,
     content => consul::sorted_json($config_hash, $consul::pretty_config, $consul::pretty_config_indent),
-    validate_cmd => "${consul::bin_dir}/${consul::binary_name} validate %",
+    validate_cmd => "${consul::bin_dir}/${consul::binary_name} validate ${consul::config_dir}",
   }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -124,12 +124,12 @@ class consul::config (
   }
 
   file { 'consul config.json':
-    ensure  => present,
-    path    => "${consul::config_dir}/config.json",
-    owner   => $consul::user_real,
-    group   => $consul::group_real,
-    mode    => $consul::config_mode,
-    content => consul::sorted_json($config_hash, $consul::pretty_config, $consul::pretty_config_indent),
+    ensure       => present,
+    path         => "${consul::config_dir}/config.json",
+    owner        => $consul::user_real,
+    group        => $consul::group_real,
+    mode         => $consul::config_mode,
+    content      => consul::sorted_json($config_hash, $consul::pretty_config, $consul::pretty_config_indent),
     validate_cmd => "${consul::bin_dir}/${consul::binary_name} validate ${consul::config_dir}",
   }
 


### PR DESCRIPTION
Make use of the [Puppet validete_cmd](https://puppet.com/docs/puppet/latest/types/file.html#file-attribute-validate_cmd). I think it makes most sense to valide the whole folder if purge_config_dir is false and some additional configs exist.