### PR TITLE
Update validation for service checks to support gRPC health checks.

### DIFF
--- a/lib/puppet/functions/consul/validate_checks.rb
+++ b/lib/puppet/functions/consul/validate_checks.rb
@@ -27,14 +27,15 @@ Puppet::Functions.create_function(:'consul::validate_checks') do
             if check_types_defined > 1
                 raise Puppet::ParseError.new('multiple check types cannot be specified in a single check definition')
             elsif check_types_defined == 0
-                raise Puppet::ParseError.new('One of the following check types must be defined: http, tcp, grpc, script, or ttl')
+                puts obj
+                raise Puppet::ParseError.new('one of the following check types must be defined: http, tcp, grpc, script, or ttl')
             end
 
-            if (is_http || is_script || is_tcp || is_grpc) && !has_interval
+            if (!is_ttl && !has_interval)
                 raise Puppet::ParseError.new('interval must be defined for tcp, http, grpc, and script checks')
             end
 
-            if is_ttl && has_interval
+            if (is_ttl && has_interval)
                 raise Puppet::ParseError.new('interval must not be defined for ttl checks')
             end
         else

--- a/lib/puppet/functions/consul/validate_checks.rb
+++ b/lib/puppet/functions/consul/validate_checks.rb
@@ -15,28 +15,27 @@ Puppet::Functions.create_function(:'consul::validate_checks') do
             validate_checks(c)
         end
         when Hash
-            if ( (obj.key?("http") || ( obj.key?("script") || obj.key?("args") ) || obj.key?("tcp")) && (! obj.key?("interval")) )
-            raise Puppet::ParseError.new('interval must be defined for tcp, http, and script checks')
+            is_http = obj.key?("http")
+            is_tcp = obj.key?("tcp")
+            is_grpc = obj.key?("grpc")
+            is_script = obj.key?("script") || obj.key?("args")
+            is_ttl = obj.key?("ttl")
+            has_interval = obj.key?("interval")
+
+            check_types_defined = [is_http, is_tcp, is_grpc, is_script, is_ttl].count(true)
+
+            if check_types_defined > 1
+                raise Puppet::ParseError.new('multiple check types cannot be specified in a single check definition')
+            elsif check_types_defined == 0
+                raise Puppet::ParseError.new('One of the following check types must be defined: http, tcp, grpc, script, or ttl')
             end
 
-            if obj.key?("ttl")
-            if (obj.key?("http") || ( obj.key?("args") || obj.key?("script") ) || obj.key?("tcp") || obj.key?("interval"))
-                raise Puppet::ParseError.new('script, http, tcp, and interval must not be defined for ttl checks')
+            if (is_http || is_script || is_tcp || is_grpc) && !has_interval
+                raise Puppet::ParseError.new('interval must be defined for tcp, http, grpc, and script checks')
             end
-            elsif obj.key?("http")
-            if (( obj.key?("args") || obj.key?("script") ) || obj.key?("tcp"))
-                raise Puppet::ParseError.new('script and tcp must not be defined for http checks')
-            end
-            elsif obj.key?("tcp")
-            if (obj.key?("http") || ( obj.key?("args") || obj.key?("script") ))
-                raise Puppet::ParseError.new('script and http must not be defined for tcp checks')
-            end
-            elsif ( obj.key?("args") || obj.key?("script") )
-            if (obj.key?("http") || obj.key?("tcp"))
-                raise Puppet::ParseError.new('http and tcp must not be defined for script checks')
-            end
-            else
-            raise Puppet::ParseError.new('One of ttl, script, tcp, or http must be defined.')
+
+            if is_ttl && has_interval
+                raise Puppet::ParseError.new('interval must not be defined for ttl checks')
             end
         else
         raise Puppet::ParseError.new("Unable to handle object of type <%s>" % obj.class.to_s)

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -40,6 +40,10 @@
 #   The IP/hostname and port for the service healthcheck. Should be in
 #   'hostname:port' format.
 #
+# [*grpc*]
+#   The IP/hostname and port for the service healthcheck.  Should be in
+#   'hostname:port' format.
+#
 # [*timeout*]
 #   A timeout value for HTTP request only
 #
@@ -69,6 +73,7 @@ define consul::check (
   $service_id               = undef,
   $status                   = undef,
   $tcp                      = undef,
+  $grpc                     = undef,
   $timeout                  = undef,
   $token                    = undef,
   $ttl                      = undef,
@@ -85,6 +90,7 @@ define consul::check (
     'script'                   => $script,
     'args'                     => $args,
     'tcp'                      => $tcp,
+    'grpc'                     => $grpc,
     'interval'                 => $interval,
     'timeout'                  => $timeout,
     'service_id'               => $service_id,

--- a/spec/defines/consul_check_spec.rb
+++ b/spec/defines/consul_check_spec.rb
@@ -19,10 +19,21 @@ describe 'consul::check' do
           }
         }
       end
+      describe 'with no valid args' do
+        let(:params) {{
+          'fakecheck' => 'http://zombo.com'
+        }}
+
+        it {
+          expect {
+            should raise_error(Puppet::Error, /one of the following check types must be defined: http, tcp, grpc, script, or ttl/)
+          }
+        }
+      end
       describe 'with script' do
         let(:params) {{
-          'interval'    => '30s',
-          'script' => 'true'
+          'interval' => '30s',
+          'script'   => 'true'
         }}
         it {
           should contain_file("/etc/consul/check_my_check.json") \
@@ -49,8 +60,8 @@ describe 'consul::check' do
       end
       describe 'with script and service_id' do
         let(:params) {{
-          'interval'    => '30s',
-          'script' => 'true',
+          'interval'   => '30s',
+          'script'     => 'true',
           'service_id' => 'my_service'
         }}
         it {
@@ -81,8 +92,8 @@ describe 'consul::check' do
       end
       describe 'with http' do
         let(:params) {{
-          'interval'    => '30s',
-          'http' => 'localhost'
+          'interval' => '30s',
+          'http'     => 'localhost'
         }}
         it {
           should contain_file("/etc/consul/check_my_check.json") \
@@ -95,8 +106,8 @@ describe 'consul::check' do
       end
       describe 'with http and service_id' do
         let(:params) {{
-          'interval'    => '30s',
-          'http' => 'localhost',
+          'interval'   => '30s',
+          'http'       => 'localhost',
           'service_id' => 'my_service'
         }}
         it {
@@ -127,8 +138,8 @@ describe 'consul::check' do
       end
       describe 'with http and removed undef values' do
         let(:params) {{
-          'interval'    => '30s',
-          'http' => 'localhost'
+          'interval' => '30s',
+          'http'     => 'localhost'
         }}
         it {
           should contain_file("/etc/consul/check_my_check.json") \
@@ -150,7 +161,7 @@ describe 'consul::check' do
       end
       describe 'with ttl and service_id' do
         let(:params) {{
-          'ttl' => '30s',
+          'ttl'        => '30s',
           'service_id' => 'my_service'
         }}
         it {
@@ -228,47 +239,57 @@ describe 'consul::check' do
           'interval' => '60s'
         }}
         it {
-          should raise_error(Puppet::Error, /script, http, tcp, and interval must not be defined for ttl checks/)
+          should raise_error(Puppet::Error, /interval must not be defined for ttl checks/)
         }
       end
       describe 'with both ttl and script' do
         let(:params) {{
-          'ttl' => '30s',
-          'script' => 'true',
+          'ttl'      => '30s',
+          'script'   => 'true',
           'interval' => '60s'
         }}
         it {
-          should raise_error(Puppet::Error, /script, http, tcp, and interval must not be defined for ttl checks/)
+          should raise_error(Puppet::Error, /multiple check types cannot be specified in a single check definition/)
         }
       end
       describe 'with both ttl and http' do
         let(:params) {{
-          'ttl' => '30s',
-          'http' => 'http://localhost/health',
+          'ttl'      => '30s',
+          'http'     => 'http://localhost/health',
           'interval' => '60s'
         }}
         it {
-          should raise_error(Puppet::Error, /script, http, tcp, and interval must not be defined for ttl checks/)
+          should raise_error(Puppet::Error, /multiple check types cannot be specified in a single check definition/)
         }
       end
       describe 'with both ttl and tcp' do
         let(:params) {{
-          'ttl' => '30s',
-          'tcp' => 'localhost',
+          'ttl'      => '30s',
+          'tcp'      => 'localhost',
           'interval' => '60s'
         }}
         it {
-          should raise_error(Puppet::Error, /script, http, tcp, and interval must not be defined for ttl checks/)
+          should raise_error(Puppet::Error, /multiple check types cannot be specified in a single check definition/)
         }
       end
       describe 'with both script and http' do
         let(:params) {{
-          'script' => 'true',
-          'http' => 'http://localhost/health',
+          'script'   => 'true',
+          'http'     => 'http://localhost/health',
           'interval' => '60s'
         }}
         it {
-          should raise_error(Puppet::Error, /script and tcp must not be defined for http checks/)
+          should raise_error(Puppet::Error, /multiple check types cannot be specified in a single check definition/)
+        }
+      end
+      describe 'with both script and grpc' do
+        let(:params) {{
+          'script'   => 'true',
+          'grpc'     => 'localhost:9000/svc',
+          'interval' => '60s'
+        }}
+        it {
+          should raise_error(Puppet::Error, /multiple check types cannot be specified in a single check definition/)
         }
       end
       describe 'with script but no interval' do
@@ -276,7 +297,7 @@ describe 'consul::check' do
           'script' => 'true',
         }}
         it {
-          should raise_error(Puppet::Error, /interval must be defined for tcp, http, and script checks/)
+          should raise_error(Puppet::Error, /interval must be defined for tcp, http, grpc, and script checks/)
         }
       end
       describe 'with http but no interval' do
@@ -284,7 +305,7 @@ describe 'consul::check' do
           'http' => 'http://localhost/health',
         }}
         it {
-          should raise_error(Puppet::Error, /interval must be defined for tcp, http, and script checks/)
+          should raise_error(Puppet::Error, /interval must be defined for tcp, http, grpc, and script checks/)
         }
       end
       describe 'with tcp but no interval' do
@@ -292,14 +313,22 @@ describe 'consul::check' do
           'tcp' => 'localhost',
         }}
         it {
-          should raise_error(Puppet::Error, /interval must be defined for tcp, http, and script checks/)
+          should raise_error(Puppet::Error, /interval must be defined for tcp, http, grpc, and script checks/)
+        }
+      end
+      describe 'with grpc but no interval' do
+        let(:params) {{
+          'grpc' => 'localhost:9000',
+        }}
+        it {
+          should raise_error(Puppet::Error, /interval must be defined for tcp, http, grpc, and script checks/)
         }
       end
       describe 'with a / in the id' do
         let(:params) {{
-          'ttl' => '30s',
+          'ttl'        => '30s',
           'service_id' => 'my_service',
-          'id' => 'aa/bb',
+          'id'         => 'aa/bb',
         }}
         it { should contain_file("/etc/consul/check_aa_bb.json") \
             .with_content(/"id" *: *"aa\/bb"/)
@@ -307,9 +336,9 @@ describe 'consul::check' do
       end
       describe 'with multiple / in the id' do
         let(:params) {{
-          'ttl' => '30s',
+          'ttl'        => '30s',
           'service_id' => 'my_service',
-          'id' => 'aa/bb/cc',
+          'id'         => 'aa/bb/cc',
         }}
         it { should contain_file("/etc/consul/check_aa_bb_cc.json") \
             .with_content(/"id" *: *"aa\/bb\/cc"/)

--- a/spec/defines/consul_check_spec.rb
+++ b/spec/defines/consul_check_spec.rb
@@ -23,7 +23,6 @@ describe 'consul::check' do
         let(:params) {{
           'fakecheck' => 'http://zombo.com'
         }}
-
         it {
           expect {
             should raise_error(Puppet::Error, /one of the following check types must be defined: http, tcp, grpc, script, or ttl/)

--- a/spec/functions/consul_validate_checks_spec.rb
+++ b/spec/functions/consul_validate_checks_spec.rb
@@ -5,7 +5,7 @@ describe 'consul::validate_checks' do
   describe 'validate script and http' do
     it {should run.with_params([
       {
-        'http'    => 'localhost',
+        'http'   => 'localhost',
         'script' => 'true'
       }
     ]).and_raise_error(Exception) }
@@ -23,7 +23,7 @@ describe 'consul::validate_checks' do
   describe 'validate http and tcp' do
     it {should run.with_params([
       {
-        'tcp'    => 'localhost',
+        'tcp'  => 'localhost',
         'http' => 'true'
       }
     ]).and_raise_error(Exception) }
@@ -32,8 +32,8 @@ describe 'consul::validate_checks' do
   describe 'validate script check' do
     it {should run.with_params([
       {
-        'interval'    => '30s',
-        'script' => 'true'
+        'interval' => '30s',
+        'script'   => 'true'
       }
     ])}
   end
@@ -62,11 +62,19 @@ describe 'consul::validate_checks' do
     ]).and_raise_error(Exception) }
   end
 
+  describe 'validate grpc missing interval' do
+    it {should run.with_params([
+      {
+        'grpc' => 'localhost:9000'
+      }
+    ]).and_raise_error(Exception) }
+  end
+
   describe 'validate script and ttl' do
     it {should run.with_params([
       {
         'script' => 'true',
-        'ttl' => 'true'
+        'ttl'    => 'true'
       }
     ]).and_raise_error(Exception) }
   end
@@ -75,7 +83,7 @@ describe 'consul::validate_checks' do
     it {should run.with_params([
       {
         'http' => 'localhost',
-        'ttl' => 'true'
+        'ttl'  => 'true'
       }
     ]).and_raise_error(Exception) }
   end
@@ -89,10 +97,29 @@ describe 'consul::validate_checks' do
     ]).and_raise_error(Exception) }
   end
 
+  describe 'validate grpc and ttl' do
+    it {should run.with_params([
+      {
+        'tcp'  => 'localhost',
+        'grpc' => 'localhost:9000',
+        'ttl'  => 'true'
+      }
+    ]).and_raise_error(Exception) }
+  end
+
   describe 'validate tcp check' do
     it {should run.with_params([
       {
         'tcp'      => 'localhost:80',
+        'interval' => '30s',
+      }
+    ])}
+  end
+
+  describe 'validate grpc check' do
+    it {should run.with_params([
+      {
+        'grpc'      => 'localhost:80',
         'interval' => '30s',
       }
     ])}


### PR DESCRIPTION
As stated in the title, this adds support for specifying a gRPC health check when defining the check of a service.

This should be safe to enforce, given that this library already has a minimum supported version newer than when gRPC health check support was added to Consul.