### PR TITLE
Service and Nodemeta for queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ consul_prepared_query { 'consul':
   service_failover_dcs => [ 'dc1', 'dc2' ],
   service_only_passing => true,
   service_tags         => [ 'tag1', 'tag2' ],
+  service_meta         => { 'version' => '1.2.3' },
   ttl                  => 10,
 }
 ```
@@ -364,6 +365,7 @@ consul_prepared_query { 'consul':
   service_failover_dcs => [ 'dc1', 'dc2' ],
   service_only_passing => true,
   service_tags         => [ '${match(2)}' ], # lint:ignore:single_quote_string_with_variables
+  node_meta            => { 'is_virtual' => 'false' },
   template             => true,
   template_regexp      => '^consul-(.*)-(.*)$',
   template_type        => 'name_prefix_match',

--- a/lib/puppet/provider/consul_prepared_query/default.rb
+++ b/lib/puppet/provider/consul_prepared_query/default.rb
@@ -146,6 +146,8 @@ Puppet::Type.type(:consul_prepared_query).provide(
     service_failover_dcs = @resource[:service_failover_dcs]
     service_only_passing = @resource[:service_only_passing]
     service_tags = @resource[:service_tags]
+    node_meta = @resource[:node_meta]
+    service_meta = @resource[:service_meta]
     ttl = @resource[:ttl]
     port = @resource[:port]
     hostname = @resource[:hostname]
@@ -167,6 +169,8 @@ Puppet::Type.type(:consul_prepared_query).provide(
         },
         'OnlyPassing' => service_only_passing,
         'Tags' => service_tags,
+        'NodeMeta' => node_meta,
+        'ServiceMeta' => service_meta
       },
       'DNS' => {
         'TTL' => "#{ttl}s"

--- a/lib/puppet/type/consul_prepared_query.rb
+++ b/lib/puppet/type/consul_prepared_query.rb
@@ -138,4 +138,18 @@ Puppet::Type.newtype(:consul_prepared_query) do
       raise ArgumentError, 'The template type must be a string' unless value.is_a?(String)
     end
   end
+
+  newparam(:node_meta) do
+    desc 'List of user-defined key/value pairs to filter on NodeMeta'
+    validate do |value|
+      raise ArgumentError, 'NodeMeta type must be a hash' unless value.is_a?(Hash)
+    end
+  end
+
+  newparam(:service_meta) do
+    desc 'List of user-defined key/value pairs to filter on ServiceMeta'
+    validate do |value|
+      raise ArgumentError, 'ServiceMeta type must be a hash' unless value.is_a?(Hash)
+    end
+  end
 end

--- a/spec/unit/puppet/type/consul_prepared_query_spec.rb
+++ b/spec/unit/puppet/type/consul_prepared_query_spec.rb
@@ -7,6 +7,24 @@ describe Puppet::Type.type(:consul_prepared_query) do
     end.to raise_error(Puppet::Error, %r{Title or name must be provided})
   end
 
+  it 'fails if node_meta is not a hash' do
+    expect do
+      Puppet::Type.type(:consul_prepared_query).new(
+        name: 'testing',
+        node_meta: 'test'
+      )
+    end.to raise_error(Puppet::Error, %r{NodeMeta type must be a hash})
+  end
+
+  it 'fails if service_meta is not a hash' do
+    expect do
+      Puppet::Type.type(:consul_prepared_query).new(
+        name: 'testing',
+        service_meta: 'test'
+      )
+    end.to raise_error(Puppet::Error, %r{ServiceMeta type must be a hash})
+  end
+
   context 'with query parameters provided' do
     before do
       @prepared_query = Puppet::Type.type(:consul_prepared_query).new(
@@ -17,7 +35,9 @@ describe Puppet::Type.type(:consul_prepared_query) do
         service_failover_dcs: %w[dc1 dc2],
         service_tags: %w[tag1 tag2],
         service_only_passing: true,
-        ttl: 10
+        ttl: 10,
+        node_meta: { 'is_virtual' => 'false' },
+        service_meta: { 'version' => '1.2.3' }
       )
     end
 
@@ -27,6 +47,14 @@ describe Puppet::Type.type(:consul_prepared_query) do
 
     it 'defaults to http' do
       expect(@prepared_query[:protocol]).to eq(:http)
+    end
+
+    it 'returns node_meta hash' do
+      expect(@prepared_query[:node_meta]).to eq({ 'is_virtual' => 'false' })
+    end
+
+    it 'returns service_meta hash' do
+      expect(@prepared_query[:service_meta]).to eq({ 'version' => '1.2.3' })
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Consul supports adding [NodeMeta](https://www.consul.io/api-docs/query#nodemeta) and [ServiceMeta](https://www.consul.io/api-docs/query#servicemeta) hashes to [prepared queries](https://www.consul.io/api-docs/query). This PR allows the user to utilize this option with this Puppet module. Providing the hashes is optional.
#### This Pull Request (PR) fixes the following issues
n/a.

