### PR TITLE
Package install: Fix ordering when data_dir isnt managed

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -76,7 +76,7 @@ class consul::install {
         User[$consul::user_real] -> Package[$consul::package_name]
       }
 
-      if $consul::data_dir {
+      if $consul::data_dir and $consul::manage_data_dir {
         Package[$consul::package_name] -> File[$real_data_dir]
       }
     }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -249,20 +249,24 @@ describe 'consul class' do
     end
   end
 
-  # rubocop:disable RSpec/RepeatedExampleGroupBody
-  context 'package based installation' do
+  context 'cleanup' do
     it 'cleans up old mess' do
       pp = <<-EOS
         service { 'consul':
           ensure => 'stopped',
           enable => false,
         }
-        -> file { '/opt/consul':
+        -> file { ['/opt/consul', '/var/lib/consul', '/etc/default/consul', '/etc/sysconfig/consul']:
           ensure => 'absent',
           force  => true,
         }
         -> file { '/etc/systemd/system/consul.service':
-          ensure => absent,
+          ensure => 'absent',
+        }
+        ~> exec { 'reload systemd':
+          command     => 'systemctl daemon-reload',
+          path        => $facts['path'],
+          refreshonly => true,
         }
       EOS
 
@@ -271,16 +275,31 @@ describe 'consul class' do
       apply_manifest(pp, catch_changes: true)
     end
 
+    describe file(['/opt/consul', '/var/lib/consul']) do
+      it { is_expected.not_to be_directory }
+    end
+  end
+
+  # no fedora packages available
+  context 'package based installation', if: fact('os.name') != 'Fedora' do
     it 'runs consul via package with explicit default data_dir' do
       pp = <<-EOS
       class { 'consul':
         install_method  => 'package',
         manage_repo     => $facts['os']['name'] != 'Archlinux',
         init_style      => 'unmanaged',
-        manage_data_dir => false,
+        manage_data_dir => true,
+        manage_group    => false,
+        manage_user     => false,
+        config_dir      => '/etc/consul.d/',
         config_hash     => {
-          'data_dir' => '/var/lib/consul', # default dir, created by the package, not the module
-        }
+          'server'   => true,
+        },
+      }
+      systemd::dropin_file { 'foo.conf':
+        unit           => 'consul.service',
+        content        => "[Unit]\nConditionFileNotEmpty=\nConditionFileNotEmpty=/etc/consul.d/config.json",
+        notify_service => true,
       }
       EOS
 
@@ -290,10 +309,6 @@ describe 'consul class' do
     end
 
     describe file('/opt/consul') do
-      it { is_expected.not_to be_directory }
-    end
-
-    describe file('/var/lib/consul') do
       it { is_expected.to be_directory }
     end
 
@@ -302,41 +317,12 @@ describe 'consul class' do
       it { is_expected.to be_running }
     end
 
-    describe command('consul version') do
-      its(:stdout) { is_expected.to match %r{Consul v} }
-    end
-
-    it 'runs consul via package without explicit default data_dir' do
-      pp = <<-EOS
-      class { 'consul':
-        install_method  => 'package',
-        manage_repo     => $facts['os']['name'] != 'Archlinux',
-        init_style      => 'unmanaged',
-        manage_data_dir => false,
-      }
-      EOS
-
-      # Run it twice and test for idempotency
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
-    end
-
-    describe file('/opt/consul') do
-      it { is_expected.not_to be_directory }
-    end
-
-    describe file('/var/lib/consul') do
-      it { is_expected.to be_directory }
-    end
-
-    describe service('consul') do
-      it { is_expected.to be_enabled }
-      it { is_expected.to be_running }
+    describe package('consul') do
+      it { is_expected.to be_installed }
     end
 
     describe command('consul version') do
       its(:stdout) { is_expected.to match %r{Consul v} }
     end
-    # rubocop:enable RSpec/RepeatedExampleGroupBody
   end
 end

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,0 +1,6 @@
+# Needed for os.distro.codebase fact
+if $facts['os']['name'] == 'Ubuntu' and $facts['os']['release']['full'] == '18.04' and versioncmp($facts['puppetversion'], '7') <= 0 {
+  package{'lsb-release':
+    ensure => present,
+  }
+}


### PR DESCRIPTION
Previously, we ensured that the package resources comes before creating
a file resource for the data dir. This doesn't always make sense. The
rpm/deb packages (depending in the platform) will create the directory for us, so we
don't need to care about it.

Contains https://github.com/voxpupuli/puppet-consul/pull/604 to proove it's a bug.