### PR TITLE
manage_repo: ensure that we refresh the package list before installing consul

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -65,7 +65,11 @@ class consul::install {
     'package': {
       if $consul::manage_repo {
         include hashi_stack::repo
-        Class['hashi_stack::repo'] -> Package[$consul::package_name]
+        if $facts['os']['family'] == 'Debian' {
+          Exec['apt_update'] -> Package[$consul::package_name]
+        } else {
+          Class['hashi_stack::repo'] -> Package[$consul::package_name]
+        }
       }
       package { $consul::package_name:
         ensure => $consul::package_ensure,


### PR DESCRIPTION


by including the hashistack_repo class, we get the correct apt repo. It will also notify the apt_update exec resource. We just need to ensure that the exec happens before we install consul.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
