### PR TITLE
fixed systemd err "Failed to parse service type, ignoring: exec"

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,7 +25,7 @@ class consul::config (
     case $consul::init_style_real {
       'systemd': {
         $type = if ($config_hash['retry_join'] == undef or $config_hash['retry_join'].length < 2) {
-          'exec'
+          'simple'
         } else {
           'notify'
         }

--- a/templates/consul.systemd.epp
+++ b/templates/consul.systemd.epp
@@ -5,7 +5,7 @@
       Optional[String] $extra_options,
       Boolean $allow_binding_to_root_ports,
       Boolean $enable_beta_ui,
-      Enum['exec', 'notify'] $type,
+      Enum['simple', 'notify'] $type,
 | -%>
 # THIS FILE IS MANAGED BY PUPPET
 [Unit]


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
systemd <err>   {daemon}        1       [/etc/systemd/system/consul.service:8] Failed to parse service type, ignoring: exec

#### This Pull Request (PR) fixes the following issues
Fixes #640
