### PR TITLE
use X-Consul-Token header instead of token query parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1110,7 +1110,7 @@ The following parameters are available in the `consul_acl` type.
 
 Token for accessing the ACL API
 
-Default value: `''`
+Default value: `anonymous`
 
 ##### <a name="-consul_acl--api_tries"></a>`api_tries`
 
@@ -1179,7 +1179,7 @@ The following parameters are available in the `consul_key_value` type.
 
 Token for accessing the ACL API
 
-Default value: `''`
+Default value: `anonymous`
 
 ##### <a name="-consul_key_value--api_tries"></a>`api_tries`
 
@@ -1373,7 +1373,7 @@ The following parameters are available in the `consul_prepared_query` type.
 
 Token for accessing the ACL API
 
-Default value: `''`
+Default value: `anonymous`
 
 ##### <a name="-consul_prepared_query--api_tries"></a>`api_tries`
 

--- a/lib/puppet/provider/consul_acl/default.rb
+++ b/lib/puppet/provider/consul_acl/default.rb
@@ -41,8 +41,9 @@ Puppet::Type.type(:consul_acl).provide(
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true if uri.instance_of? URI::HTTPS
 
-    path = uri.request_uri + "/list?token=#{acl_api_token}"
-    req = Net::HTTP::Get.new(path)
+    path = uri.request_uri + "/list"
+    http_headers = { 'X-Consul-Token' => "#{acl_api_token}" }
+    req = Net::HTTP::Get.new(path, http_headers)
     res = nil
     res_code = nil
 
@@ -58,7 +59,7 @@ Puppet::Type.type(:consul_acl).provide(
         res_code = res.code
         break if res_code == '200'
       rescue Errno::ECONNREFUSED => e
-        Puppet.debug("#{uri}/list?token=<redacted> #{e.class} #{e.message}")
+        Puppet.debug("#{uri}/list #{e.class} #{e.message}")
         res_code = e.class.to_s
       end
     end
@@ -94,8 +95,9 @@ Puppet::Type.type(:consul_acl).provide(
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true if uri.instance_of? URI::HTTPS
     acl_api_token = @resource[:acl_api_token]
-    path = uri.request_uri + "/#{method}?token=#{acl_api_token}"
-    req = Net::HTTP::Put.new(path)
+    path = uri.request_uri + "/#{method}"
+    http_headers = { 'X-Consul-Token' => "#{acl_api_token}" }
+    req = Net::HTTP::Put.new(path, http_headers)
     req.body = body.to_json if body
     res = http.request(req)
     raise(Puppet::Error, "Session #{name} create: invalid return code #{res.code} uri: #{path} body: #{req.body}") if res.code != '200'

--- a/lib/puppet/provider/consul_acl/default.rb
+++ b/lib/puppet/provider/consul_acl/default.rb
@@ -41,8 +41,8 @@ Puppet::Type.type(:consul_acl).provide(
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true if uri.instance_of? URI::HTTPS
 
-    path = uri.request_uri + "/list"
-    http_headers = { 'X-Consul-Token' => "#{acl_api_token}" }
+    path = "#{uri.request_uri}/list"
+    http_headers = { 'X-Consul-Token' => acl_api_token.to_s }
     req = Net::HTTP::Get.new(path, http_headers)
     res = nil
     res_code = nil
@@ -96,7 +96,7 @@ Puppet::Type.type(:consul_acl).provide(
     http.use_ssl = true if uri.instance_of? URI::HTTPS
     acl_api_token = @resource[:acl_api_token]
     path = uri.request_uri + "/#{method}"
-    http_headers = { 'X-Consul-Token' => "#{acl_api_token}" }
+    http_headers = { 'X-Consul-Token' => acl_api_token.to_s }
     req = Net::HTTP::Put.new(path, http_headers)
     req.body = body.to_json if body
     res = http.request(req)

--- a/lib/puppet/provider/consul_key_value/default.rb
+++ b/lib/puppet/provider/consul_key_value/default.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:consul_key_value).provide(
     uri = URI(consul_url)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true if uri.instance_of? URI::HTTPS
-    http_headers = { 'X-Consul-Token' => "#{acl_api_token}" }
+    http_headers = { 'X-Consul-Token' => acl_api_token.to_s }
     req = Net::HTTP::Get.new(uri.request_uri, http_headers)
     res = nil
 
@@ -91,7 +91,7 @@ Puppet::Type.type(:consul_key_value).provide(
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true if uri.instance_of? URI::HTTPS
     acl_api_token = @resource[:acl_api_token]
-    http_headers = { 'X-Consul-Token' => "#{acl_api_token}" }
+    http_headers = { 'X-Consul-Token' => acl_api_token.to_s }
     [uri.request_uri, http, http_headers]
   end
 

--- a/lib/puppet/provider/consul_prepared_query/default.rb
+++ b/lib/puppet/provider/consul_prepared_query/default.rb
@@ -38,7 +38,7 @@ Puppet::Type.type(:consul_prepared_query).provide(
     uri = URI("#{protocol}://#{hostname}:#{port}/v1/query")
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true if uri.instance_of? URI::HTTPS
-    http_headers = { 'X-Consul-Token' => "#{acl_api_token}" }
+    http_headers = { 'X-Consul-Token' => acl_api_token.to_s }
     req = Net::HTTP::Get.new(uri.request_uri, http_headers)
     res = nil
 
@@ -81,7 +81,7 @@ Puppet::Type.type(:consul_prepared_query).provide(
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true if uri.instance_of? URI::HTTPS
     acl_api_token = @resource[:acl_api_token]
-    http_headers = { 'X-Consul-Token' => "#{acl_api_token}" }
+    http_headers = { 'X-Consul-Token' => acl_api_token.to_s }
     [uri.request_uri, http, http_headers]
   end
 

--- a/lib/puppet/type/consul_acl.rb
+++ b/lib/puppet/type/consul_acl.rb
@@ -22,7 +22,7 @@ Puppet::Type.newtype(:consul_acl) do
     validate do |value|
       raise ArgumentError, 'ACL API token must be a string' unless value.is_a?(String)
     end
-    defaultto ''
+    defaultto 'anonymous'
   end
 
   newproperty(:rules) do

--- a/lib/puppet/type/consul_key_value.rb
+++ b/lib/puppet/type/consul_key_value.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:consul_key_value) do
     validate do |value|
       raise ArgumentError, 'ACL API token must be a string' unless value.is_a?(String)
     end
-    defaultto ''
+    defaultto 'anonymous'
   end
 
   newparam(:datacenter) do

--- a/lib/puppet/type/consul_prepared_query.rb
+++ b/lib/puppet/type/consul_prepared_query.rb
@@ -26,7 +26,7 @@ Puppet::Type.newtype(:consul_prepared_query) do
     validate do |value|
       raise ArgumentError, 'ACL API token must be a string' unless value.is_a?(String)
     end
-    defaultto ''
+    defaultto 'anonymous'
   end
 
   newparam(:service_name) do

--- a/spec/unit/puppet/provider/consul_key_value_spec.rb
+++ b/spec/unit/puppet/provider/consul_key_value_spec.rb
@@ -27,8 +27,8 @@ describe Puppet::Type.type(:consul_key_value).provider(:default) do
             'ModifyIndex' => 1_350_503 },
         ]
 
-        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse&token=sampleToken').
-          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse').
+          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby', 'X-Consul-Token' => 'sampleToken' }).
           to_return(status: 400, body: '', headers: {}).times(2).then.
           to_return(status: 200, body: JSON.dump(kv_content), headers: {})
 
@@ -40,8 +40,8 @@ describe Puppet::Type.type(:consul_key_value).provider(:default) do
 
     context 'when the first three responses are unexpected' do
       it 'silentlies fail to prefetch' do
-        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse&token=sampleToken').
-          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse').
+          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby', 'X-Consul-Token' => 'sampleToken' }).
           to_return(status: 400, body: '', headers: {})
 
         described_class.reset
@@ -52,8 +52,8 @@ describe Puppet::Type.type(:consul_key_value).provider(:default) do
 
     context 'when a timeout is received' do
       it 'does not handle the timeout' do
-        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse&token=sampleToken').
-          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse').
+          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby', 'X-Consul-Token' => 'sampleToken' }).
           to_timeout
 
         described_class.reset
@@ -98,12 +98,12 @@ describe Puppet::Type.type(:consul_key_value).provider(:default) do
             'ModifyIndex' => 1_350_503 },
         ]
 
-        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse&token=sampleToken').
-          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse').
+          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby', 'X-Consul-Token' => 'sampleToken' }).
           to_return(status: 200, body: JSON.dump(kv_content), headers: {})
 
-        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc2&recurse&token=sampleToken').
-          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc2&recurse').
+          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby', 'X-Consul-Token' => 'sampleToken' }).
           to_return(status: 404, body: '', headers: {})
 
         described_class.reset
@@ -117,8 +117,8 @@ describe Puppet::Type.type(:consul_key_value).provider(:default) do
   describe '#exists?' do
     context 'when resource does not exists' do
       it 'returns false' do
-        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse&token=sampleToken').
-          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse').
+          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby', 'X-Consul-Token' => 'sampleToken' }).
           to_return(status: 404, body: '', headers: {})
 
         described_class.reset
@@ -138,8 +138,8 @@ describe Puppet::Type.type(:consul_key_value).provider(:default) do
             'ModifyIndex' => 1_350_503 },
         ]
 
-        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse&token=sampleToken').
-          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse').
+          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby', 'X-Consul-Token' => 'sampleToken' }).
           to_return(status: 200, body: JSON.dump(kv_content), headers: {})
 
         described_class.reset
@@ -161,11 +161,11 @@ describe Puppet::Type.type(:consul_key_value).provider(:default) do
             'ModifyIndex' => 1_350_503 },
         ]
 
-        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse&token=sampleToken').
-          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse').
+          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby', 'X-Consul-Token' => 'sampleToken' }).
           to_return(status: 200, body: JSON.dump(kv_content), headers: {})
 
-        stub_request(:put, 'http://localhost:8500/v1/kv/sample/key?dc=dc1&flags=0&token=sampleToken').
+        stub_request(:put, 'http://localhost:8500/v1/kv/sample/key?dc=dc1&flags=0').
           with(body: 'sampleValue',
                headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
           to_return(status: 200, body: '', headers: {})
@@ -188,11 +188,11 @@ describe Puppet::Type.type(:consul_key_value).provider(:default) do
             'ModifyIndex' => 1_350_503 },
         ]
 
-        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse&token=sampleToken').
-          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse').
+          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby', 'X-Consul-Token' => 'sampleToken' }).
           to_return(status: 200, body: JSON.dump(kv_content), headers: {})
 
-        stub_request(:put, 'http://localhost:8500/v1/kv/sample/key?dc=dc1&flags=0&token=sampleToken').
+        stub_request(:put, 'http://localhost:8500/v1/kv/sample/key?dc=dc1&flags=0').
           with(body: 'sampleValue',
                headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
           to_return(status: 200, body: '', headers: {})
@@ -226,11 +226,11 @@ describe Puppet::Type.type(:consul_key_value).provider(:default) do
         )
         resources = { 'sample/key' => resource }
 
-        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse&token=sampleToken').
-          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse').
+          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby', 'X-Consul-Token' => 'sampleToken' }).
           to_return(status: 200, body: JSON.dump(kv_content), headers: {})
 
-        stub_request(:put, 'http://localhost:8500/v1/kv/sample/key?dc=dc1&flags=2&token=sampleToken').
+        stub_request(:put, 'http://localhost:8500/v1/kv/sample/key?dc=dc1&flags=2').
           with(body: 'sampleValue',
                headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
           to_return(status: 200, body: '', headers: {})
@@ -253,11 +253,11 @@ describe Puppet::Type.type(:consul_key_value).provider(:default) do
             'ModifyIndex' => 1_350_503 },
         ]
 
-        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse&token=sampleToken').
-          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse').
+          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby', 'X-Consul-Token' => 'sampleToken' }).
           to_return(status: 200, body: JSON.dump(kv_content), headers: {})
 
-        stub_request(:put, 'http://localhost:8500/v1/kv/sample/key?dc=dc1&flags=0&token=sampleToken').
+        stub_request(:put, 'http://localhost:8500/v1/kv/sample/key?dc=dc1&flags=0').
           with(body: 'sampleValue',
                headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
           to_return(status: 400, body: '', headers: {})
@@ -282,12 +282,12 @@ describe Puppet::Type.type(:consul_key_value).provider(:default) do
             'ModifyIndex' => 1_350_503 },
         ]
 
-        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse&token=sampleToken').
-          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse').
+          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby', 'X-Consul-Token' => 'sampleToken' }).
           to_return(status: 200, body: JSON.dump(kv_content), headers: {})
 
-        stub_request(:delete, 'http://localhost:8500/v1/kv/sample/key?dc=dc1&token=sampleToken').
-          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        stub_request(:delete, 'http://localhost:8500/v1/kv/sample/key?dc=dc1').
+          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby', 'X-Consul-Token' => 'sampleToken' }).
           to_return(status: 200, body: '', headers: {})
 
         described_class.reset
@@ -308,12 +308,12 @@ describe Puppet::Type.type(:consul_key_value).provider(:default) do
             'ModifyIndex' => 1_350_503 },
         ]
 
-        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse&token=sampleToken').
-          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        stub_request(:get, 'http://localhost:8500/v1/kv/?dc=dc1&recurse').
+          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby', 'X-Consul-Token' => 'sampleToken' }).
           to_return(status: 200, body: JSON.dump(kv_content), headers: {})
 
-        stub_request(:delete, 'http://localhost:8500/v1/kv/sample/key?dc=dc1&token=sampleToken').
-          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        stub_request(:delete, 'http://localhost:8500/v1/kv/sample/key?dc=dc1').
+          with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby', 'X-Consul-Token' => 'sampleToken' }).
           to_return(status: 400, body: '', headers: {})
 
         described_class.reset


### PR DESCRIPTION
#### Pull Request (PR) description
Hi,

this change replaces the usage of the token query paramter with the HTTP header X-Consul-Token when interacting with ACLs, key/values and prepared queries.
The header was introduced in Consul [0.6.0](https://github.com/hashicorp/consul/blob/main/CHANGELOG.md#060-december-3-2015).
The change is necessary as the token query parameter is marked [deprecated in Consul 1.15.x](https://developer.hashicorp.com/consul/docs/upgrading/upgrade-specific#deprecating-authentication-via-token-query-parameter). Using it triggers deprecation warnings in the Consul logs each time this module runs on a server.

~~~bash
Jan 26 10:44:11 consul03 consul[11454]: agent.http: This request used the token query parameter which is deprecated and will be removed in Consul 1.17: logUrl=/v1/query?token=<hidden>
~~~

Luckily it was not removed yet so there is still time to fix it.
I've tested the changes with our internal Puppet module in Vagrant.

This pull request was created by my best knowladge. I'm working as system administrator and have no ruby expertise but got some help from colleagues in our company. Thus said I'm open for any suggestion to improve this.

Thanks in advance!

#### This Pull Request (PR) fixes the following issues
n/a.

