### PR TITLE
facts[fqdn] is a legacy fact, use facts['networking']['fqdn'] in the example.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,7 @@
 #    class { 'consul':
 #      config_hash => {
 #        'datacenter'   => 'east-aws',
-#        'node_name'    => $facts['fqdn'],
+#        'node_name'    => $facts['networking']['fqdn'],
 #        'pretty_config => true,
 #        'retry-join'   => ['172.16.0.1'],
 #      },


### PR DESCRIPTION
https://www.puppet.com/docs/puppet/8/core_facts.html#fqdn