### PR TITLE
fix incorrect log_file variable name in FreeBSD Template

### DIFF
--- a/templates/consul.freebsd-rcconf.erb
+++ b/templates/consul.freebsd-rcconf.erb
@@ -14,5 +14,5 @@ consul_group="<%= scope.lookupvar('consul::group') %>"
 consul_dir="<%= scope.lookupvar('consul::data_dir') %>"
 <% end %>
 <% if scope.lookupvar('consul::log_file') %>
-consul_log_file="<%= scope.lookupvar('consul::consul_log_file') %>"
+consul_log_file="<%= scope.lookupvar('consul::log_file') %>"
 <% end %>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Minor change to ERB Template for FreeBSD correcting typo on log_file parameter name.


#### This Pull Request (PR) fixes the following issues

Fixes #690


