### PR TITLE
actually use unwrapped config_hash value

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -158,7 +158,7 @@ class consul (
     Sensitive => $config_hash.unwrap,
     default   => $config_hash
   }
-  $config_hash_real = deep_merge($config_defaults, $config_hash)
+  $config_hash_real = deep_merge($config_defaults, $_config_hash)
 
   if $install_method == 'docker' {
     $user_real         = undef

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,7 @@
 # @api private
 class consul::install {
   assert_private()
-  $real_data_dir = pick($consul::data_dir, $consul::config_hash[data_dir], $consul::config_defaults[data_dir])
+  $real_data_dir = pick($consul::data_dir, $consul::config_hash_real[data_dir], $consul::config_defaults[data_dir])
 
   if $consul::manage_data_dir {
     file { $real_data_dir:

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -231,6 +231,16 @@ describe 'consul' do
         it { is_expected.to contain_file('consul config').with_content(sensitive(%r{"ui":true})) }
       end
 
+      context 'When passing "config_hash" as Sensitive' do
+        let :params do
+          {
+            config_hash: RSpec::Puppet::RawString.new('Sensitive({})'),
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+      end
+
       context 'When not installing UI' do
         let(:params) do
           {


### PR DESCRIPTION
Sensitive support was added 2022 with #614, but somehow nobody noticed yet. Passing `$config_hash` as Sensitive[Hash] fails ...

```
Internal Server Error: org.jruby.exceptions.RuntimeError: (PreformattedError) Evaluation Error: Error while evaluating a Function Call, deep_merge: unexpected argument type Puppet::Pops::Types::PSensitiveType::Sensitive, only expects hash arguments
```

... because `$config_hash_real` does not actually use the unwrapped config_hash value. 